### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -611,6 +611,26 @@
                 }
             }
 
+            // Helper function to escape HTML special characters
+            function escapeHTML(str) {
+                return str.replace(/[&<>"']/g, function (m) {
+                    switch (m) {
+                        case '&':
+                            return '&amp;';
+                        case '<':
+                            return '&lt;';
+                        case '>':
+                            return '&gt;';
+                        case '"':
+                            return '&quot;';
+                        case "'":
+                            return '&#39;';
+                        default:
+                            return m;
+                    }
+                });
+            }
+
             // Function to render web results
             function renderWebResults(query) {
                 webResults.innerHTML = '';
@@ -645,7 +665,7 @@
                 // Add search query to conversation history
                 const userQueryCard = document.createElement('div');
                 userQueryCard.className = 'ai-card w-full card-bg-gradient rounded-2xl p-6 shadow-lg';
-                userQueryCard.innerHTML = `<span class="text-gray-300"><b>You:</b> ${query}</span>`;
+                userQueryCard.innerHTML = `<span class="text-gray-300"><b>You:</b> ${escapeHTML(query)}</span>`;
                 searchResults.appendChild(userQueryCard);
 
                 // Check for hardcoded knowledge panel entries first


### PR DESCRIPTION
Potential fix for [https://github.com/kanishk2007dev/kanishk/security/code-scanning/3](https://github.com/kanishk2007dev/kanishk/security/code-scanning/3)

The best way to fix this problem is to escape any user-supplied content before inserting it as HTML, unless you have a strong guarantee that the input is safe and intended to be HTML. In this specific case, only the `query` variable is user-controlled; the rest of the template is controlled by the developer. 

The ideal fix is, therefore:
- Sanitize `query` by escaping any HTML special characters (`<`, `>`, `&`, `"`, `'`) before inserting it into the template literal that sets `innerHTML` on line 648.

We can do this by introducing a helper function, for example, `escapeHTML`, which converts any special characters in the user input to their respective HTML entities, and then interpolate the escaped result. This change should be limited to the context of line 648.

The helper function `escapeHTML` can be defined at the start of the `<script>` section before it’s first used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
