### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -636,18 +636,30 @@
                 webResults.innerHTML = '';
 
                 const dummyResults = [
-                    { title: `About ${query}`, url: `https://example.com/about/${query.toLowerCase().replace(/\s/g, '-')}`, snippet: `Learn more about the history and details of ${query}.` },
-                    { title: `${query} products and services`, url: `https://example.com/${query.toLowerCase().replace(/\s/g, '-')}/products`, snippet: `A comprehensive list of products and services provided by ${query}.` },
-                    { title: `${query} News and Updates`, url: `https://example.com/news/${query.toLowerCase().replace(/\s/g, '-')}`, snippet: `The latest news and announcements regarding ${query}.` }
+                    { 
+                        title: `About ${escapeHTML(query)}`, 
+                        url: `https://example.com/about/${encodeURIComponent(query.toLowerCase().replace(/\s/g, '-'))}`, 
+                        snippet: `Learn more about the history and details of ${escapeHTML(query)}.`
+                    },
+                    { 
+                        title: `${escapeHTML(query)} products and services`, 
+                        url: `https://example.com/${encodeURIComponent(query.toLowerCase().replace(/\s/g, '-'))}/products`, 
+                        snippet: `A comprehensive list of products and services provided by ${escapeHTML(query)}.`
+                    },
+                    { 
+                        title: `${escapeHTML(query)} News and Updates`, 
+                        url: `https://example.com/news/${encodeURIComponent(query.toLowerCase().replace(/\s/g, '-'))}`, 
+                        snippet: `The latest news and announcements regarding ${escapeHTML(query)}.`
+                    }
                 ];
                 
                 dummyResults.forEach(result => {
                     const resultDiv = document.createElement('div');
                     resultDiv.className = "card-bg-gradient rounded-xl p-4 shadow-md hover:ring-2 hover:ring-cyan-500 transition-shadow";
                     resultDiv.innerHTML = `
-                        <h4 class="text-xl font-semibold text-cyan-400"><a href="${result.url}" target="_blank" rel="noopener noreferrer">${result.title}</a></h4>
-                        <p class="text-green-500 text-sm mt-1">${result.url}</p>
-                        <p class="text-gray-400 mt-2">${result.snippet}</p>
+                        <h4 class="text-xl font-semibold text-cyan-400"><a href="${escapeHTML(result.url)}" target="_blank" rel="noopener noreferrer">${escapeHTML(result.title)}</a></h4>
+                        <p class="text-green-500 text-sm mt-1">${escapeHTML(result.url)}</p>
+                        <p class="text-gray-400 mt-2">${escapeHTML(result.snippet)}</p>
                     `;
                     webResults.appendChild(resultDiv);
                 });


### PR DESCRIPTION
Potential fix for [https://github.com/kanishk2007dev/kanishk/security/code-scanning/2](https://github.com/kanishk2007dev/kanishk/security/code-scanning/2)

The best way to fix this problem is to ensure that any user-supplied data interpolated into HTML using `innerHTML` is properly escaped to prevent HTML interpretation/meta-character injection. We already see that an `escapeHTML` function is used elsewhere in the code (line 668), so we should use this function to encode all occurrences of `${query}` used in the template literals for the dummy web results (in lines 639-641 and again in 648, 649, and 650). In particular, all places where `${query}` or data derived from it is placed in the HTML must be properly escaped before being assigned to `innerHTML`.

This will involve:

- Wrapping each interpolated `${query}` and derived data inside `dummyResults` (title, URL, snippet) using `escapeHTML(...)`.
- When constructing the HTML in `innerHTML`, ensure that interpolated data is always escaped.

**Required:**  
- The `escapeHTML` function must be in scope and capable of safely encoding all HTML meta-characters (`<`, `>`, `&`, `"`, `'`, `/`).
- Review `dummyResults` and update how its properties are set and rendered so all data displayed in the DOM is escaped.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
