### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
     <style>
         body {
             font-family: 'Inter', sans-serif;
@@ -574,7 +576,9 @@
                 
                 aiSummaryContent.innerHTML = '';
                 const summaryParagraph = document.createElement('p');
-                summaryParagraph.innerHTML = response.text;
+                // Convert Markdown to safe HTML using marked.js and DOMPurify
+                const html = DOMPurify.sanitize(marked.parse(response.text));
+                summaryParagraph.innerHTML = html;
                 aiSummaryContent.appendChild(summaryParagraph);
 
                 if (response.sources && response.sources.length > 0) {


### PR DESCRIPTION
Potential fix for [https://github.com/kanishk2007dev/kanishk/security/code-scanning/1](https://github.com/kanishk2007dev/kanishk/security/code-scanning/1)

To fix this vulnerability, we must ensure that any user-controlled or untrusted string that reaches `.innerHTML` does not contain unescaped meta-characters that would be interpreted as HTML. The best approach is:

**Option 1:** Use textContent instead of innerHTML when rendering text that does not intentionally contain HTML/Markdown.  
**Option 2:** If Markdown rendering is required (the example aims to allow bolding via Markdown in systemPrompt and dummyText), convert safe Markdown to HTML using a trusted library, and sanitize the resulting HTML before injecting it into the DOM.

Here, the dummy response intentionally includes Markdown formatting. Ideally, we should:
- Parse Markdown to HTML in a way that only allows safe tags.
- Sanitize the resulting HTML to remove any executable code or dangerous markup before assigning to `innerHTML`.

**Steps:**
- Use a client-side Markdown parser (e.g., marked.js or showdown).
- Use DOMPurify (a well-known, lightweight sanitization library) to sanitize HTML after parsing Markdown.
- Apply this both to the AI response summary and to sources, if any source data (titles) are user-controlled.

**Concrete Changes:**
- Add imports for marked.js and DOMPurify in `index.html`.
- Replace `summaryParagraph.innerHTML = response.text;` to:
    - Parse `response.text` (Markdown) to HTML with `marked.parse`.
    - Sanitize the result with `DOMPurify.sanitize`.
    - Assign the sanitized HTML to `.innerHTML`.

Follow this flow wherever user-controlled data is rendered as HTML—in this snippet, just for the AI summary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
